### PR TITLE
Updated to use FrooxEngine.Store.dll

### DIFF
--- a/GifImporter.cs
+++ b/GifImporter.cs
@@ -9,15 +9,16 @@ using FrooxEngine;
 using HarmonyLib;
 using ResoniteModLoader;
 using Elements.Core;
+using FrooxEngine.Store;
 
 namespace GifImporter;
 
 public class GifImporter : ResoniteMod
 {
-	// Port by LeCloutPanda
+	// Ported and update by LeCloutPanda(lecloutpanda.github.io)
 	public override string Name    => "GifImporter";
 	public override string Author  => "astral";
-	public override string Version => "1.1.4";
+	public override string Version => "1.1.5";
 	public override string Link    => "https://git.astralchan.xyz/astral/GifImporter";
 
 	[AutoRegisterConfigKey]
@@ -53,9 +54,9 @@ public class GifImporter : ResoniteMod
 				var type = client.ResponseHeaders.Get("content-type");
 				validGif = type == "image/gif";
 			}
-			/* TODO: Support neosdb links
-			else if (uri.Scheme == "neosdb"){
-				// neosdb handling here
+			/* TODO: Support resdb links
+			else if (uri.Scheme == "resdb"){
+				// resdb handling here
 			} */
 			if (!validGif) {
 				Debug($"{path} is not a gif, returning true");

--- a/GifImporter.cs
+++ b/GifImporter.cs
@@ -15,7 +15,7 @@ namespace GifImporter;
 
 public class GifImporter : ResoniteMod
 {
-	// Ported and update by LeCloutPanda(lecloutpanda.github.io)
+	// Ported and updated by LeCloutPanda(lecloutpanda.github.io)
 	public override string Name    => "GifImporter";
 	public override string Author  => "astral";
 	public override string Version => "1.1.5";

--- a/GifImporter.csproj
+++ b/GifImporter.csproj
@@ -23,7 +23,7 @@
 		<!-- windows standalone -->
 		<ResonitePath Condition="Exists('C:\Resonite\app\')">C:\Resonite\app\</ResonitePath>
 	</PropertyGroup>
-	
+
 	<ItemGroup>
 		<Reference Include="0Harmony">
 			<HintPath>$(ResonitePath)Libraries\0Harmony.dll</HintPath>
@@ -39,6 +39,9 @@
 		</Reference>
 		<Reference Include="FrooxEngine">
 			<HintPath>$(ResonitePath)Resonite_Data\Managed\FrooxEngine.dll</HintPath>
+		</Reference>
+		<Reference Include="FrooxEngine.Store">
+			<HintPath>$(ResonitePath)Resonite_Data\Managed\FrooxEngine.Store.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 


### PR DESCRIPTION
Previous update broke the mod. All that was needed was to reference FrooxEngine.Store.dll.

If you are fine with it can I release a build if you are not going to?

- Panda