### PR TITLE
Modify the aspect ratio

### DIFF
--- a/GifImporter.cs
+++ b/GifImporter.cs
@@ -211,6 +211,7 @@ public class GifImporter : ResoniteMod
                 UnlitMaterial _UnlitMaterial = targetSlot.GetComponent<UnlitMaterial>();
                 _UVAtlasAnimator.ScaleField.Target = _UnlitMaterial.TextureScale;
                 _UVAtlasAnimator.OffsetField.Target = _UnlitMaterial.TextureOffset;
+                _UnlitMaterial.BlendMode.Value = BlendMode.Cutout;
 
                 // Set inventory preview to first frame
                 ItemTextureThumbnailSource _inventoryPreview = targetSlot.GetComponent<ItemTextureThumbnailSource>();

--- a/GifImporter.cs
+++ b/GifImporter.cs
@@ -18,7 +18,7 @@ public class GifImporter : ResoniteMod
     {
     public override string Name    => "GifImporter";
     public override string Author  => "astral";
-    public override string Version => "1.1.8";
+    public override string Version => "1.1.9";
     public override string Link    => "https://github.com/astralchan/GifImporter";
 
     [AutoRegisterConfigKey]
@@ -205,8 +205,8 @@ public class GifImporter : ResoniteMod
                 _TimeIntDriver.Target.Target = _UVAtlasAnimator.Frame;
                 _UVAtlasAnimator.AtlasInfo.Target = _AtlasInfo;
 
-                QuadMesh _QuadMesh = targetSlot.GetComponent<QuadMesh>();
-                _QuadMesh.Size.Value = new float2(frameWidth, frameHeight).Normalized;
+                TextureSizeDriver _TextureSizeDriver = targetSlot.GetComponent<TextureSizeDriver>();
+                _TextureSizeDriver.Premultiply.Value = new float2(gifRows, gifCols);
 
                 UnlitMaterial _UnlitMaterial = targetSlot.GetComponent<UnlitMaterial>();
                 _UVAtlasAnimator.ScaleField.Target = _UnlitMaterial.TextureScale;


### PR DESCRIPTION
Closes [9](https://github.com/astralchan/GifImporter/issues/9)

The following fixes work well for the most part, but do not resolve the following issues with the original existence.
Doesn't work if Generate square sqriteSheet is false, but not a workaround. Here is an excerpt from the log
```log
C:\Users\jhpark\Desktop\image.gif

PM 11:45:56.635 (130 FPS)	Exception running asynchronous task:
System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException: The operation is invalid [GDI+ status: Win32Error]
  at System.Drawing.GDIPlus.CheckStatus (System.Drawing.Status status) [0x0020c] in <04abc238e1e64b378e01047493bf1e72>:0 
  at System.Drawing.Image.Save (System.String filename, System.Drawing.Imaging.ImageCodecInfo encoder, System.Drawing.Imaging.EncoderParameters encoderParams) [0x0003d] in <04abc238e1e64b378e01047493bf1e72>:0 
  at System.Drawing.Image.Save (System.String filename, System.Drawing.Imaging.ImageFormat format) [0x00044] in <04abc238e1e64b378e01047493bf1e72>:0 
  at (wrapper remoting-invoke-with-check) System.Drawing.Image.Save(string,System.Drawing.Imaging.ImageFormat)
  at GifImporter.GifImporter+GifImporterPatch+<>c__DisplayClass0_0+<<Prefix>b__0>d.MoveNext () [0x004c4] in <883a27393e4845f3ad569f038f1bba2d>:0 
   --- End of inner exception stack trace ---
---> (Inner Exception #0) System.InvalidOperationException: The operation is invalid [GDI+ status: Win32Error]
  at System.Drawing.GDIPlus.CheckStatus (System.Drawing.Status status) [0x0020c] in <04abc238e1e64b378e01047493bf1e72>:0 
  at System.Drawing.Image.Save (System.String filename, System.Drawing.Imaging.ImageCodecInfo encoder, System.Drawing.Imaging.EncoderParameters encoderParams) [0x0003d] in <04abc238e1e64b378e01047493bf1e72>:0 
  at System.Drawing.Image.Save (System.String filename, System.Drawing.Imaging.ImageFormat format) [0x00044] in <04abc238e1e64b378e01047493bf1e72>:0 
  at (wrapper remoting-invoke-with-check) System.Drawing.Image.Save(string,System.Drawing.Imaging.ImageFormat)
  at GifImporter.GifImporter+GifImporterPatch+<>c__DisplayClass0_0+<<Prefix>b__0>d.MoveNext () [0x004c4] in <883a27393e4845f3ad569f038f1bba2d>:0 <---


  at System.Environment.get_StackTrace () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at Elements.Core.UniLog.Error (System.String message, System.Boolean stackTrace) [0x00000] in <e82f3b1262114d5988440ed3b93e15b7>:0 
  at FrooxEngine.CoroutineManager.CheckExceptions (System.Threading.Tasks.Task task) [0x00000] in <7ca75709ea5a4e1d8cb31cf7aba17500>:0 
  at System.Threading.Tasks.ContinuationTaskFromTask.InnerInvoke () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.Execute () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.ExecutionContextCallback (System.Object obj) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.ExecuteWithThreadLocal (System.Threading.Tasks.Task& currentTaskSlot) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.ExecuteEntry (System.Boolean bPreventDoubleExecution) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
PM 11:45:56.638 (130 FPS)	Exception running asynchronous task:
System.AggregateException: One or more errors occurred. ---> System.InvalidOperationException: The operation is invalid [GDI+ status: Win32Error]
  at System.Drawing.GDIPlus.CheckStatus (System.Drawing.Status status) [0x0020c] in <04abc238e1e64b378e01047493bf1e72>:0 
  at System.Drawing.Image.Save (System.String filename, System.Drawing.Imaging.ImageCodecInfo encoder, System.Drawing.Imaging.EncoderParameters encoderParams) [0x0003d] in <04abc238e1e64b378e01047493bf1e72>:0 
  at System.Drawing.Image.Save (System.String filename, System.Drawing.Imaging.ImageFormat format) [0x00044] in <04abc238e1e64b378e01047493bf1e72>:0 
  at (wrapper remoting-invoke-with-check) System.Drawing.Image.Save(string,System.Drawing.Imaging.ImageFormat)
  at GifImporter.GifImporter+GifImporterPatch+<>c__DisplayClass0_0+<<Prefix>b__0>d.MoveNext () [0x004c4] in <883a27393e4845f3ad569f038f1bba2d>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at FrooxEngine.UniversalImporter+<UndoableImportRoutine>d__3.MoveNext () [0x00060] in <7ca75709ea5a4e1d8cb31cf7aba17500>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at FrooxEngine.UniversalImporter+<>c__DisplayClass2_0+<<UndoableImport>b__0>d.MoveNext () [0x0006d] in <7ca75709ea5a4e1d8cb31cf7aba17500>:0 
   --- End of inner exception stack trace ---
---> (Inner Exception #0) System.InvalidOperationException: The operation is invalid [GDI+ status: Win32Error]
  at System.Drawing.GDIPlus.CheckStatus (System.Drawing.Status status) [0x0020c] in <04abc238e1e64b378e01047493bf1e72>:0 
  at System.Drawing.Image.Save (System.String filename, System.Drawing.Imaging.ImageCodecInfo encoder, System.Drawing.Imaging.EncoderParameters encoderParams) [0x0003d] in <04abc238e1e64b378e01047493bf1e72>:0 
  at System.Drawing.Image.Save (System.String filename, System.Drawing.Imaging.ImageFormat format) [0x00044] in <04abc238e1e64b378e01047493bf1e72>:0 
  at (wrapper remoting-invoke-with-check) System.Drawing.Image.Save(string,System.Drawing.Imaging.ImageFormat)
  at GifImporter.GifImporter+GifImporterPatch+<>c__DisplayClass0_0+<<Prefix>b__0>d.MoveNext () [0x004c4] in <883a27393e4845f3ad569f038f1bba2d>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at FrooxEngine.UniversalImporter+<UndoableImportRoutine>d__3.MoveNext () [0x00060] in <7ca75709ea5a4e1d8cb31cf7aba17500>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x0000c] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess (System.Threading.Tasks.Task task) [0x0003e] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification (System.Threading.Tasks.Task task) [0x00028] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.ValidateEnd (System.Threading.Tasks.Task task) [0x00008] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Runtime.CompilerServices.TaskAwaiter.GetResult () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at FrooxEngine.UniversalImporter+<>c__DisplayClass2_0+<<UndoableImport>b__0>d.MoveNext () [0x0006d] in <7ca75709ea5a4e1d8cb31cf7aba17500>:0 <---


  at System.Environment.get_StackTrace () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at Elements.Core.UniLog.Error (System.String message, System.Boolean stackTrace) [0x00000] in <e82f3b1262114d5988440ed3b93e15b7>:0 
  at FrooxEngine.CoroutineManager.CheckExceptions (System.Threading.Tasks.Task task) [0x00000] in <7ca75709ea5a4e1d8cb31cf7aba17500>:0 
  at System.Threading.Tasks.ContinuationTaskFromTask.InnerInvoke () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.Execute () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.ExecutionContextCallback (System.Object obj) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.ExecuteWithThreadLocal (System.Threading.Tasks.Task& currentTaskSlot) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.ExecuteEntry (System.Boolean bPreventDoubleExecution) [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.Tasks.Task.System.Threading.IThreadPoolWorkItem.ExecuteWorkItem () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading.ThreadPoolWorkQueue.Dispatch () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
  at System.Threading._ThreadPoolWaitCallback.PerformWaitCallback () [0x00000] in <9577ac7a62ef43179789031239ba8798>:0 
```